### PR TITLE
on gcc, handle #define PACKED_ATTRIBUTE

### DIFF
--- a/utp_types.h
+++ b/utp_types.h
@@ -23,7 +23,7 @@
 #ifndef __UTP_TYPES_H__
 #define __UTP_TYPES_H__
 
-#ifdef __GNUC__
+#if defined BROKEN_GCC_STRUCTURE_PACKING && defined __GNUC__
 	// Used for gcc tool chains accepting but not supporting pragma pack
 	// See http://gcc.gnu.org/onlinedocs/gcc/Type-Attributes.html
 	#define PACKED_ATTRIBUTE __attribute__((__packed__))


### PR DESCRIPTION
by opting for pragma unless we define BROKEN_GCC_STRUCTURE_PACKING [for older gcc w/o pragma pack support]
@rmcdonald @aqk @jjoyce-bittorrent 